### PR TITLE
Add static type checker before interpretation

### DIFF
--- a/culebra/ast.py
+++ b/culebra/ast.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from culebra.token import Token, TokenType
-from typing import List, Optional, Union
+from typing import List, Optional, Union, TypeVar, Generic
+
+T = TypeVar('T')
 
 
 class ASTNode(ABC):
@@ -76,7 +78,7 @@ class Program(Block):
     def __init__(self, statements: List[Statement]):
         super().__init__(statements)
 
-class LiteralValue[T](Expression, ABC):
+class LiteralValue(Generic[T], Expression, ABC):
     def __init__(self, token: Token, value: T):
         super().__init__(token)
         self.value = value

--- a/culebra/interpreter/interpreter.py
+++ b/culebra/interpreter/interpreter.py
@@ -1,6 +1,7 @@
 from culebra import ast
 from culebra.interpreter.environment import Environment
 from culebra.token import TokenType
+from culebra.type_checker import TypeChecker, TypeErrorException
 
 """
 Culebra Interpreter Implementation
@@ -114,6 +115,12 @@ class Interpreter:
     def evaluate(self, program: ast.Program):
         self.last_error = None
         self.last_node = None
+        # Run type checker before interpretation
+        try:
+            TypeChecker().check(program)
+        except TypeErrorException as e:
+            self.last_error = e
+            raise e
         return self.eval_node(program, self.root_environment)
 
     def eval_node(self, node, environment):

--- a/culebra/type_checker.py
+++ b/culebra/type_checker.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict
+
+from culebra import ast
+from culebra.token import TokenType
+from culebra.type_system import (
+    BaseType,
+    INT,
+    FLOAT,
+    BOOL,
+    STRING,
+    ArrayType,
+    FunctionType,
+    UNKNOWN,
+)
+
+class TypeErrorException(Exception):
+    pass
+
+@dataclass
+class TypeEnvironment:
+    values: Dict[str, BaseType]
+    parent: 'TypeEnvironment | None' = None
+
+    def get(self, name: str) -> BaseType:
+        if name in self.values:
+            return self.values[name]
+        if self.parent:
+            return self.parent.get(name)
+        return UNKNOWN
+
+    def assign(self, name: str, typ: BaseType):
+        if name in self.values:
+            self.values[name] = typ
+        elif self.parent and name in self.parent.values:
+            self.parent.assign(name, typ)
+        else:
+            self.values[name] = typ
+
+    def create_child(self) -> 'TypeEnvironment':
+        return TypeEnvironment({}, self)
+
+class TypeChecker:
+    def __init__(self):
+        self.env = TypeEnvironment({})
+
+    def check(self, node: ast.ASTNode):
+        for cls in type(node).__mro__:
+            method_name = f'check_{cls.__name__}'
+            method = getattr(self, method_name, None)
+            if method:
+                return method(node)
+        return self.generic_check(node)
+
+    def generic_check(self, node: ast.ASTNode):
+        raise TypeErrorException(f'No type check method for {type(node)}')
+
+    # Program / Block
+    def check_Program(self, node: ast.Program):
+        for stmt in node.statements:
+            self.check(stmt)
+        return None
+
+    def check_Block(self, node: ast.Block):
+        for stmt in node.statements:
+            self.check(stmt)
+        return None
+
+    # Literals
+    def check_Integer(self, node: ast.Integer):
+        return INT
+
+    def check_Float(self, node: ast.Float):
+        return FLOAT
+
+    def check_String(self, node: ast.String):
+        return STRING
+
+    def check_Bool(self, node: ast.Bool):
+        return BOOL
+
+    def check_Array(self, node: ast.Array):
+        if not node.elements:
+            return ArrayType(UNKNOWN)
+        element_types = [self.check(elem) for elem in node.elements]
+        first = element_types[0]
+        for i, t in enumerate(element_types[1:], start=1):
+            if t != first:
+                raise TypeErrorException(
+                    f'Array elements must be of the same type: expected {first}, got {t} at index {i}'
+                )
+        return ArrayType(first)
+
+    def check_Identifier(self, node: ast.Identifier):
+        return self.env.get(node.value)
+
+    def check_Assignment(self, node: ast.Assignment):
+        value_type = self.check(node.value)
+        if isinstance(node.identifier, ast.Identifier):
+            self.env.assign(node.identifier.value, value_type)
+        elif isinstance(node.identifier, ast.BracketAccess):
+            target_type = self.check(node.identifier.target)
+            index_type = self.check(node.identifier.index)
+            if index_type not in (INT, UNKNOWN):
+                raise TypeErrorException(
+                    f'Index expression must be INT, got {index_type}'
+                )
+            if isinstance(target_type, ArrayType):
+                if target_type.element_type != value_type:
+                    raise TypeErrorException(
+                        f'Cannot assign {value_type} to array of {target_type.element_type}'
+                    )
+            else:
+                raise TypeErrorException(
+                    f'Bracket assignment only valid for arrays, got {target_type}'
+                )
+        return None
+
+    def check_BracketAccess(self, node: ast.BracketAccess):
+        target_type = self.check(node.target)
+        index_type = self.check(node.index)
+        if index_type not in (INT, UNKNOWN):
+            raise TypeErrorException(
+                f'Index expression must be INT, got {index_type}'
+            )
+        if isinstance(target_type, ArrayType):
+            return target_type.element_type
+        if target_type == STRING:
+            return STRING
+        if target_type == UNKNOWN:
+            return UNKNOWN
+        raise TypeErrorException(
+            f'Bracket access only valid on arrays or strings, got {target_type}'
+        )
+
+    # Operations
+    def check_BinaryOperation(self, node: ast.BinaryOperation):
+        left = self.check(node.left)
+        right = self.check(node.right)
+        op = node.token.type
+
+        if op in [TokenType.PLUS, TokenType.MINUS, TokenType.MUL, TokenType.DIV]:
+            if UNKNOWN in (left, right):
+                other = right if left is UNKNOWN else left
+                if other in (INT, FLOAT):
+                    return other
+                if op == TokenType.PLUS and other == STRING:
+                    return STRING
+                return UNKNOWN
+            if left != right:
+                raise TypeErrorException(
+                    f'Operands for {op.name} must have the same type, got {left} and {right}'
+                )
+            if left not in (INT, FLOAT):
+                if op == TokenType.PLUS and left == STRING:
+                    return STRING
+                raise TypeErrorException(
+                    f'Operator {op.name} not supported for {left}'
+                )
+            return left
+
+        if op in [TokenType.EQUAL, TokenType.NOT_EQUAL]:
+            if UNKNOWN in (left, right):
+                return BOOL
+            if left != right:
+                raise TypeErrorException(
+                    f'Operands for {op.name} must be of the same type, got {left} and {right}'
+                )
+            return BOOL
+
+        if op in [TokenType.LESS, TokenType.GREATER, TokenType.LESS_EQ, TokenType.GREATER_EQ]:
+            if UNKNOWN in (left, right):
+                other = right if left is UNKNOWN else left
+                if other in (INT, FLOAT):
+                    return BOOL
+                return BOOL
+            if left != right or left not in (INT, FLOAT):
+                raise TypeErrorException(
+                    f'Comparison {op.name} requires numeric operands of the same type, got {left} and {right}'
+                )
+            return BOOL
+
+        if op in [TokenType.AND, TokenType.OR]:
+            if UNKNOWN in (left, right):
+                return BOOL
+            if left != BOOL or right != BOOL:
+                raise TypeErrorException(
+                    f'Logical operator {op.name} requires boolean operands, got {left} and {right}'
+                )
+            return BOOL
+
+        raise TypeErrorException(f'Unsupported binary operator {op}')
+
+    def check_PrefixOperation(self, node: ast.PrefixOperation):
+        value_type = self.check(node.value)
+        op = node.token.type
+        if op == TokenType.MINUS:
+            if value_type is UNKNOWN:
+                return UNKNOWN
+            if value_type not in (INT, FLOAT):
+                raise TypeErrorException(
+                    f'Unary - expects INT or FLOAT, got {value_type}'
+                )
+            return value_type
+        if op == TokenType.NOT:
+            if value_type is UNKNOWN:
+                return BOOL
+            if value_type != BOOL:
+                raise TypeErrorException(
+                    f'not operator requires BOOL, got {value_type}'
+                )
+            return BOOL
+        raise TypeErrorException(f'Unsupported prefix operator {op}')
+
+    def check_Conditional(self, node: ast.Conditional):
+        cond_type = self.check(node.condition)
+        if cond_type != BOOL:
+            raise TypeErrorException(
+                f'Condition expression must be BOOL, got {cond_type}'
+            )
+        self.check(node.body)
+        if node.otherwise:
+            self.check(node.otherwise)
+        return None
+
+    def check_While(self, node: ast.While):
+        cond_type = self.check(node.condition)
+        if cond_type != BOOL:
+            raise TypeErrorException(
+                f'Condition expression must be BOOL, got {cond_type}'
+            )
+        self.check(node.body)
+        return None
+
+    def check_For(self, node: ast.For):
+        self.check(node.pre)
+        cond_type = self.check(node.condition)
+        if cond_type != BOOL:
+            raise TypeErrorException(
+                f'Condition expression must be BOOL, got {cond_type}'
+            )
+        self.check(node.post)
+        self.check(node.body)
+        return None
+
+    def check_FunctionDefinition(self, node: ast.FunctionDefinition):
+        # Register function but skip body type checking for simplicity
+        self.env.assign(node.name.value, FunctionType())
+        child = self.env.create_child()
+        self.check(node.body)
+        return None
+
+    def check_FunctionCall(self, node: ast.FunctionCall):
+        self.check(node.function)
+        for arg in node.arguments:
+            self.check(arg)
+        return UNKNOWN
+
+    def check_ReturnStatement(self, node: ast.ReturnStatement):
+        self.check(node.value)
+        return None
+

--- a/culebra/type_system.py
+++ b/culebra/type_system.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from typing import Any
+from enum import Enum, auto
+
+class BaseType:
+    """Base class for Culebra types."""
+    def __eq__(self, other: Any) -> bool:
+        return type(self) is type(other)
+
+    def __repr__(self) -> str:
+        return self.__class__.__name__
+
+class IntType(BaseType):
+    pass
+
+class FloatType(BaseType):
+    pass
+
+class BoolType(BaseType):
+    pass
+
+class StringType(BaseType):
+    pass
+
+@dataclass
+class ArrayType(BaseType):
+    element_type: BaseType
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, ArrayType) and self.element_type == other.element_type
+
+    def __repr__(self) -> str:
+        return f"ArrayType({self.element_type})"
+
+class FunctionType(BaseType):
+    pass
+
+class UnknownType(BaseType):
+    pass
+
+# Predefined singleton instances
+INT = IntType()
+FLOAT = FloatType()
+BOOL = BoolType()
+STRING = StringType()
+UNKNOWN = UnknownType()

--- a/test/type_checker_test.py
+++ b/test/type_checker_test.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+
+from culebra.interpreter.interpreter import Interpreter
+from culebra.lexer import Lexer
+from culebra.parser import Parser
+from culebra.type_checker import TypeErrorException
+
+class TestTypeChecker(TestCase):
+    def _run_error(self, source, msg):
+        tokens = Lexer().tokenize(source)
+        parser = Parser(tokens)
+        program = parser.parse()
+        interpreter = Interpreter()
+        with self.assertRaisesRegex(TypeErrorException, msg):
+            interpreter.evaluate(program)
+
+    def _run_ok(self, source):
+        tokens = Lexer().tokenize(source)
+        parser = Parser(tokens)
+        program = parser.parse()
+        interpreter = Interpreter()
+        try:
+            interpreter.evaluate(program)
+        except TypeErrorException as e:
+            self.fail(f"Unexpected type error: {e}")
+
+    def test_array_mixed_types(self):
+        source = "a = [1, true]"
+        self._run_error(source, "Array elements must be of the same type")
+
+    def test_binary_type_mismatch(self):
+        source = "a = 1 + true"
+        self._run_error(source, "Operands for PLUS must have the same type")
+
+    def test_array_assignment_mismatch(self):
+        source = """
+arr = [1,2]
+arr[0] = "x"
+"""
+        self._run_error(source, "Cannot assign StringType to array of IntType")
+
+    def test_valid_cases(self):
+        self._run_ok("a = [1,2]")
+        self._run_ok("b = 1 + 2")
+        self._run_ok("""
+arr = [1,2]
+arr[0] = 3
+""")
+


### PR DESCRIPTION
## Summary
- implement `type_system` defining base types
- add `type_checker` to enforce type rules before running programs
- enforce type checking in the interpreter
- update AST generic syntax for Python 3.11
- create tests verifying type checker errors
- improve type checker error messages and extend tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498f52aef8832b828bf4268e02fb9e